### PR TITLE
Tt fixes

### DIFF
--- a/data/companions/worldgen/structure/companions_teddytower.json
+++ b/data/companions/worldgen/structure/companions_teddytower.json
@@ -7,10 +7,7 @@
 
   "max_distance_from_center": 80,
 
-  "biomes": [
-    "bigglobe:temperate_dense_forest",
-    "bigglobe:warm_dense_forest"
-  ],
+  "biomes": ["bigglobe:temperate_dense_forest", "bigglobe:warm_dense_forest"],
 
   "step": "surface_structures",
 
@@ -18,7 +15,8 @@
     "absolute": 0
   },
 
-  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "project_start_to_heightmap": "MOTION_BLOCKING_NO_LEAVES",
+  "terrain_adaptation": "beard_box",
 
   "use_expansion_hack": false,
 

--- a/data/companions/worldgen/structure/companions_tent.json
+++ b/data/companions/worldgen/structure/companions_tent.json
@@ -5,12 +5,8 @@
   "max_distance_from_center": 80,
   "step": "underground_structures",
   "start_height": {
-    "type": "minecraft:biased_to_bottom",
-    "min_inclusive": { "absolute": 64 },
-    "max_inclusive": { "absolute": 800 },
-    "inner": 1
+    "absolute": 65
   },
-  "project_start_to_heightmap": "WORLD_SURFACE_WG",
   "terrain_adaptation": "beard_thin",
   "use_expansion_hack": false,
   "spawn_overrides": {},

--- a/data/companions/worldgen/structure/companions_tent.json
+++ b/data/companions/worldgen/structure/companions_tent.json
@@ -6,10 +6,12 @@
   "step": "underground_structures",
   "start_height": {
     "type": "minecraft:biased_to_bottom",
-    "min_inclusive": { "absolute": 32 },
-    "max_inclusive": { "absolute": 100 },
+    "min_inclusive": { "absolute": 64 },
+    "max_inclusive": { "absolute": 800 },
     "inner": 1
   },
+  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "terrain_adaptation": "beard_thin",
   "use_expansion_hack": false,
   "spawn_overrides": {},
   "biomes": [

--- a/data/companions/worldgen/structure_set/companions_babayaga.json
+++ b/data/companions/worldgen/structure_set/companions_babayaga.json
@@ -1,0 +1,17 @@
+{
+  "structures": [
+    {
+      "structure": "companions:companions_babayaga",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "salt": 168272323,
+
+    "spacing": 30,
+
+    "separation": 10,
+
+    "type": "minecraft:random_spread"
+  }
+}

--- a/data/companions/worldgen/structure_set/companions_factory.json
+++ b/data/companions/worldgen/structure_set/companions_factory.json
@@ -1,0 +1,17 @@
+{
+  "structures": [
+    {
+      "structure": "companions:companions_factory",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "salt": 168272323,
+
+    "spacing": 60,
+
+    "separation": 20,
+
+    "type": "minecraft:random_spread"
+  }
+}

--- a/data/companions/worldgen/structure_set/companions_monkey_temple.json
+++ b/data/companions/worldgen/structure_set/companions_monkey_temple.json
@@ -1,0 +1,14 @@
+{
+  "structures": [
+    {
+      "structure": "companions:companions_monkey_temple",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "salt": 987654321,
+    "spacing": 35,
+    "separation": 20,
+    "type": "minecraft:random_spread"
+  }
+}

--- a/data/companions/worldgen/structure_set/companions_teddytower.json
+++ b/data/companions/worldgen/structure_set/companions_teddytower.json
@@ -1,0 +1,17 @@
+{
+  "structures": [
+    {
+      "structure": "companions:companions_teddytower",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "salt": 168272323,
+
+    "spacing": 40,
+
+    "separation": 15,
+
+    "type": "minecraft:random_spread"
+  }
+}

--- a/data/companions/worldgen/structure_set/companions_tent.json
+++ b/data/companions/worldgen/structure_set/companions_tent.json
@@ -1,0 +1,14 @@
+{
+  "structures": [
+    {
+      "structure": "companions:companions_tent",
+      "weight": 1
+    }
+  ],
+  "placement": {
+    "salt": 2143658709,
+    "spacing": 25,
+    "separation": 5,
+    "type": "minecraft:random_spread"
+  }
+}


### PR DESCRIPTION
Fixed some issues with spawning. Unfortunately I had to decide to limit tent spawns to Y=65. Note to self: Add support for "bigglobe:inferno" lava lakes, as they spawn at Y=128.

Teddys spawn now, also made the other structures ever so slightly less rare.